### PR TITLE
Fix grouping ranges handling zero values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 T2
+
+This repository contains a PyQt application for converting tabular data into
+KML files. Numerical grouping ranges are now calculated using equal intervals
+from the minimum (including any zero values) to the maximum value. The number
+of groups can be configured from three to five via the interface.

--- a/kml_to_csv.py
+++ b/kml_to_csv.py
@@ -11,7 +11,6 @@ from PyQt6.QtGui import QColor, QFont
 from PyQt6.QtCore import Qt, QPoint, QRect 
 
 import numpy as np
-import jenkspy
 import pandas as pd
 
 class KmlGeneratorApp(QWidget):
@@ -269,8 +268,9 @@ border: 1px solid #CCCCCC; font-weight: bold; }
         self.num_groups_label.setStyleSheet(label_style)
         num_groups_layout.addWidget(self.num_groups_label)
         self.num_groups_spinbox = QSpinBox()
-        self.num_groups_spinbox.setMinimum(1)
-        self.num_groups_spinbox.setValue(5)
+        self.num_groups_spinbox.setMinimum(3)
+        self.num_groups_spinbox.setMaximum(5)
+        self.num_groups_spinbox.setValue(3)
         self.num_groups_spinbox.valueChanged.connect(self.on_numerical_grouping_field_changed)
         self.num_groups_spinbox.setStyleSheet(spinbox_style)
         num_groups_layout.addWidget(self.num_groups_spinbox)
@@ -894,19 +894,16 @@ border: 1px solid #CCCCCC; font-weight: bold; }
             return
 
         num_groups = self.num_groups_spinbox.value()
-        
-        distinct_values = sorted(list(set(numerical_values)))
-        
-        if len(distinct_values) >= num_groups and len(distinct_values) > 1:
-            n_classes_for_jenks = min(num_groups, len(distinct_values) - 1)
-            bins = jenkspy.jenks_breaks(numerical_values, n_classes=n_classes_for_jenks)
+
+        # Determine the full range of values, explicitly including zeros
+        min_val = min(numerical_values)
+        max_val = max(numerical_values)
+
+        # Build equally sized ranges from the minimum to the maximum
+        if min_val == max_val:
+            bins = [min_val, min_val + 1] if num_groups > 1 else [min_val, min_val]
         else:
-            min_val = min(numerical_values)
-            max_val = max(numerical_values)
-            if min_val == max_val:
-                bins = [min_val, min_val + 1] if num_groups > 1 else [min_val, min_val]
-            else:
-                bins = np.linspace(min_val, max_val, num_groups + 1)
+            bins = np.linspace(min_val, max_val, num_groups + 1)
         
         bins = sorted(list(set(bins)))
         


### PR DESCRIPTION
## Summary
- ensure number of groups is configurable between three and five
- generate equal sized numerical ranges including zero values
- update readme

## Testing
- `python3 -m py_compile kml_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_68492d02ac1c8322874f7a45b3b210e7