### PR TITLE
Improve grouping with Jenks classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@ T2
 
 This repository contains a PyQt application for converting tabular data into
 
-KML files. Numerical grouping ranges are determined using Jenks natural breaks
-whenever possible, falling back to equal intervals when data variety is low.
-Zero values are included in the range calculation. The number of groups can be
-configured from three to five via the interface.
-=======
-KML files. Numerical grouping ranges are now calculated using equal intervals
-from the minimum (including any zero values) to the maximum value. The number
-of groups can be configured from three to five via the interface.
-
+KML files. Numerical grouping ranges use Jenks natural breaks with
+a fallback to equal intervals when data variety is low or when Jenks
+does not provide the requested number of boundaries. Zero values are
+considered when calculating ranges. The interface now allows selecting
+any number of groups up to twenty without the value being automatically
+reduced.


### PR DESCRIPTION
## Summary
- support up to twenty numerical groups
- implement Jenks natural breaks classification
- update README to describe the new behavior
- keep chosen group count and fall back to equal intervals when Jenks fails

## Testing
- `python -m py_compile kml_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_68510aa99884832289f4377687786490