### PR TITLE
Add single-color unique grouping mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ does not provide the requested number of boundaries. Zero values are
 considered when calculating ranges. The interface now allows selecting
 any number of groups up to twenty without the value being automatically
 reduced. Only the first twenty rows of the loaded file are shown in the
-interface. When grouping by unique values, a new checkbox allows applying
-a single color to all groups instead of choosing colors individually.
+interface. A third grouping mode lets you color all unique values with a
+single chosen color and opacity.
 
 preview table. Data may be filtered with a simple expression in the
 **Filter formula** field, for example `City=London and Value>5`.


### PR DESCRIPTION
## Summary
- add third grouping option allowing unique values to share one color
- support color picker and update UI visibility logic
- document new mode in README

## Testing
- `python -m py_compile kml_to_csv.py`

------
https://chatgpt.com/codex/tasks/task_e_685bcfb47790832294d966ad53cdc5f0