### PR TITLE
Allow editing of numeric group colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ any number of groups up to twenty without the value being automatically
 reduced. Only the first twenty rows of the loaded file are shown in the
 interface. A third grouping mode lets you color all unique values with a
 single chosen color and opacity.
+For numerical grouping by ranges, colors for all groups except the last can be
+edited individually by clicking their swatches. Changing the final gradient
+color resets the gradient from that color back to white.
 
 preview table. Data may be filtered with a simple expression in the
 **Filter formula** field, for example `City=London and Value>5`.

--- a/kml_to_csv.py
+++ b/kml_to_csv.py
@@ -1808,6 +1808,15 @@ border: 1px solid #CCCCCC; font-weight: bold; }
             self.group_colors[self.groups[index]['label']] = color
             self.update_group_display()
 
+    def pick_numeric_group_color(self, index):
+        """Allow manual selection of a numerical group color."""
+        current = self.groups[index]['color']
+        color = QColorDialog.getColor(current, self, "Выбрать цвет группы")
+        if color.isValid():
+            self.groups[index]['color'] = color
+            self.group_colors[self.groups[index]['label']] = color
+            self.update_group_display()
+
     def on_numerical_grouping_field_changed(self):
         """
         Handles the change of the numerical grouping field or number of groups.
@@ -1999,6 +2008,8 @@ border: 1px solid #CCCCCC; font-weight: bold; }
                 swatch = QLabel()
                 swatch.setFixedSize(20, 20)
                 swatch.setStyleSheet(f"background-color: {group['color'].name()}; border: 1px solid #888888;")
+                if i < len(self.groups) - 1:
+                    swatch.mousePressEvent = lambda e, idx=i: self.pick_numeric_group_color(idx)
                 g_layout.addWidget(swatch)
 
                 lower_label = QLabel(f"{self._format_range_value(group['range'][0])} - ")
@@ -2106,6 +2117,7 @@ border: 1px solid #CCCCCC; font-weight: bold; }
                 self.manual_group_bounds[group_index + 1] = {}
             self.manual_group_bounds[group_index + 1]['lower'] = new_value
 
+        self.group_colors = {}
         for i, group in enumerate(self.groups):
             manual_lower = self.manual_group_bounds.get(i, {}).get('lower')
             lower_display = manual_lower if manual_lower is not None else group['range'][0]
@@ -2114,16 +2126,7 @@ border: 1px solid #CCCCCC; font-weight: bold; }
             upper_display = manual_upper if manual_upper is not None else group['range'][1]
 
             group['label'] = f"{self._format_range_value(lower_display)} - {self._format_range_value(upper_display)}"
-            
-            num_groups = len(self.groups)
-            start_color = QColor(255, 255, 255)
-            end_color = self.end_color
-            r = start_color.red() + i * (end_color.red() - start_color.red()) // (num_groups - 1) if num_groups > 1 else start_color.red()
-            g = start_color.green() + i * (end_color.green() - start_color.green()) // (num_groups - 1) if num_groups > 1 else start_color.green()
-            b = start_color.blue() + i * (end_color.blue() - start_color.blue()) // (num_groups - 1) if num_groups > 1 else start_color.blue()
-            group_color = QColor(r, g, b)
-            self.groups[i]['color'] = group_color
-            self.group_colors[group['label']] = group_color
+            self.group_colors[group['label']] = group['color']
 
         self.update_group_display()
 


### PR DESCRIPTION
## Summary
- enable choosing colors for numerical value groups by clicking swatches
- keep manual colors when editing group bounds
- document how to customize group colors

## Testing
- `python -m py_compile kml_to_csv.py`


------
https://chatgpt.com/codex/tasks/task_e_68b050630b50832d8ead9e47cba9c9ec