### PR TITLE
Remove unused shapely Point import

### DIFF
--- a/kml_to_csv.py
+++ b/kml_to_csv.py
@@ -4,7 +4,6 @@ import csv
 # Allow very large geometry strings when reading CSV files
 csv.field_size_limit(1000000)
 import simplekml
-from shapely.geometry import Point
 from shapely import wkt
 from PyQt6.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLabel,
                              QPushButton, QFileDialog, QLineEdit, QComboBox, QColorDialog,


### PR DESCRIPTION
## Summary
- remove unused shapely.geometry Point import from `kml_to_csv.py`

## Testing
- `black --check kml_to_csv.py` *(fails: would reformat file)*
- `pip install flake8` *(fails: ProxyError 403)*
- `ruff check kml_to_csv.py` *(fails: E402, F401, F821, F811, F841)*
- `python -m py_compile kml_to_csv.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2de923710832d8bcd7fc2faddb248