### PR TITLE
Remove unused QPoint import

### DIFF
--- a/kml_to_csv.py
+++ b/kml_to_csv.py
@@ -10,7 +10,7 @@ from PyQt6.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout, QL
                              QCheckBox, QSpinBox, QTableWidget, QTableWidgetItem, QHeaderView,
                              QMessageBox, QRadioButton, QButtonGroup, QGroupBox, QScrollArea)
 from PyQt6.QtGui import QColor, QFont, QStandardItemModel, QStandardItem
-from PyQt6.QtCore import Qt, QPoint, QRect, pyqtSignal, QEvent
+from PyQt6.QtCore import Qt, QRect, pyqtSignal, QEvent
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
## Summary
- drop QPoint from PyQt6.QtCore imports in kml_to_csv

## Testing
- `python -m ruff check kml_to_csv.py`
- `black --check kml_to_csv.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2e0bb8d50832daa1c115b79c5adef